### PR TITLE
updating beepboop and botkit deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
   },
   "license": "ISC",
   "dependencies": {
-    "beepboop-botkit": "~0.0.10",
-    "botkit": "0.0.11"
+    "beepboop-botkit": "^1.1.1",
+    "botkit": "0.0.14"
   },
   "engines": {
     "node": "4.2.3"


### PR DESCRIPTION
This bumps `beepboop-botkit` and `botkit` deps to the latest, which include some fixes for:
- improved retry & reconnection logic for both the beepboop resourcer and slack rtm socket connection
- proper cleanup of connections when teams are removed to avoid memory leaks.
